### PR TITLE
Enable Metal API Validation without crashing.

### DIFF
--- a/RealityKit Drawable Queue.xcodeproj/project.pbxproj
+++ b/RealityKit Drawable Queue.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		55E30F41294A6007002ACC50 /* 90s.gif in Resources */ = {isa = PBXBuildFile; fileRef = 55E30F40294A6007002ACC50 /* 90s.gif */; };
 		D76C967926C52BDD00108A5B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C967826C52BDD00108A5B /* AppDelegate.swift */; };
 		D76C967B26C52BDD00108A5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C967A26C52BDD00108A5B /* SceneDelegate.swift */; };
 		D76C967D26C52BDD00108A5B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C967C26C52BDD00108A5B /* ViewController.swift */; };
@@ -18,7 +19,6 @@
 		D76C969926C534AD00108A5B /* CustomMaterialShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = D76C969826C534AD00108A5B /* CustomMaterialShaders.metal */; };
 		D76C969B26C5390300108A5B /* waiting.gif in Resources */ = {isa = PBXBuildFile; fileRef = D76C969A26C5390300108A5B /* waiting.gif */; };
 		D76C969D26C5538D00108A5B /* doge.gif in Resources */ = {isa = PBXBuildFile; fileRef = D76C969C26C5538D00108A5B /* doge.gif */; };
-		D76C96A426C5581E00108A5B /* 90s.gif in Resources */ = {isa = PBXBuildFile; fileRef = D76C96A326C5581E00108A5B /* 90s.gif */; };
 		D76C96A826C58FF500108A5B /* wow.gif in Resources */ = {isa = PBXBuildFile; fileRef = D76C96A526C58FF500108A5B /* wow.gif */; };
 		D76C96A926C58FF500108A5B /* celebrate.gif in Resources */ = {isa = PBXBuildFile; fileRef = D76C96A626C58FF500108A5B /* celebrate.gif */; };
 		D76C96AA26C58FF500108A5B /* heart-eyes.gif in Resources */ = {isa = PBXBuildFile; fileRef = D76C96A726C58FF500108A5B /* heart-eyes.gif */; };
@@ -26,6 +26,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		55E30F40294A6007002ACC50 /* 90s.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = 90s.gif; sourceTree = "<group>"; };
 		D76C967526C52BDD00108A5B /* RealityKit Drawable Queue.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "RealityKit Drawable Queue.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D76C967826C52BDD00108A5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D76C967A26C52BDD00108A5B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -39,7 +40,6 @@
 		D76C969826C534AD00108A5B /* CustomMaterialShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = CustomMaterialShaders.metal; sourceTree = "<group>"; };
 		D76C969A26C5390300108A5B /* waiting.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = waiting.gif; sourceTree = "<group>"; };
 		D76C969C26C5538D00108A5B /* doge.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = doge.gif; sourceTree = "<group>"; };
-		D76C96A326C5581E00108A5B /* 90s.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = 90s.gif; path = ../../../../../../../Downloads/90s.gif; sourceTree = "<group>"; };
 		D76C96A526C58FF500108A5B /* wow.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = wow.gif; sourceTree = "<group>"; };
 		D76C96A626C58FF500108A5B /* celebrate.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = celebrate.gif; sourceTree = "<group>"; };
 		D76C96A726C58FF500108A5B /* heart-eyes.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = "heart-eyes.gif"; sourceTree = "<group>"; };
@@ -109,8 +109,8 @@
 			children = (
 				D76C96A626C58FF500108A5B /* celebrate.gif */,
 				D76C96A726C58FF500108A5B /* heart-eyes.gif */,
+				55E30F40294A6007002ACC50 /* 90s.gif */,
 				D76C96A526C58FF500108A5B /* wow.gif */,
-				D76C96A326C5581E00108A5B /* 90s.gif */,
 				D76C969C26C5538D00108A5B /* doge.gif */,
 				D76C969A26C5390300108A5B /* waiting.gif */,
 			);
@@ -178,12 +178,12 @@
 				D76C96A826C58FF500108A5B /* wow.gif in Resources */,
 				D76C96AA26C58FF500108A5B /* heart-eyes.gif in Resources */,
 				D76C969D26C5538D00108A5B /* doge.gif in Resources */,
+				55E30F41294A6007002ACC50 /* 90s.gif in Resources */,
 				D76C969B26C5390300108A5B /* waiting.gif in Resources */,
 				D76C968526C52BDE00108A5B /* LaunchScreen.storyboard in Resources */,
 				D76C96B126C5D54400108A5B /* preview.gif in Resources */,
 				D76C96A926C58FF500108A5B /* celebrate.gif in Resources */,
 				D76C968226C52BDE00108A5B /* Assets.xcassets in Resources */,
-				D76C96A426C5581E00108A5B /* 90s.gif in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,7 +341,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 86ZBG2MBLH;
+				DEVELOPMENT_TEAM = 9792AFNZU9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "RealityKit Drawable Queue/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -368,7 +368,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 86ZBG2MBLH;
+				DEVELOPMENT_TEAM = 9792AFNZU9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "RealityKit Drawable Queue/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/RealityKit Drawable Queue.xcodeproj/xcshareddata/xcschemes/RealityKit Drawable Queue.xcscheme
+++ b/RealityKit Drawable Queue.xcodeproj/xcshareddata/xcschemes/RealityKit Drawable Queue.xcscheme
@@ -39,7 +39,6 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/RealityKit Drawable Queue/DrawableTextureManager.swift
+++ b/RealityKit Drawable Queue/DrawableTextureManager.swift
@@ -40,15 +40,13 @@ public class DrawableTextureManager {
     public weak var arView: ARView?
     
     public lazy var drawableQueue: TextureResource.DrawableQueue = {
-        
-        #warning("If the usage below is set to anything other than .none you need to disable Metal API Validation in the projects Scheme Settings – otherwise you will get a warning similar to: Texture at colorAttachment[0] has usage (0x02) which doesn't specify MTLTextureUsageRenderTarget (0x04) in Xcode 13 Beta")
 
         // can be whatever you like – 200 × 200 for most GIFs is probably enough
         let descriptor = TextureResource.DrawableQueue.Descriptor(
             pixelFormat: .rgba8Unorm,
             width: 200,
             height: 200,
-            usage: .shaderWrite,
+            usage: [.renderTarget, .shaderRead, .shaderWrite],
             mipmapsMode: .none
         )
         


### PR DESCRIPTION
I talked to [this guy](https://github.com/Hi-Rez) about the Metal API validation issue and he suggested I change the `TextureResource.DrawableQueue.Descriptor` from `.shaderWrite` to `[.renderTarget, .shaderRead, .shaderWrite]` and it worked; Now Metal API validation can be checked in the scheme and there is no crashing.
I removed the warning message.

I also added `90s.gif` back into the bundle because when I cloned the repo it was visible in finder but was missing in Xcode.